### PR TITLE
CLI arguments, SSLCertificateFile 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Sleight can be used in 3 ways:
 #### 3) Rules only (no setup):
 If you only want to use Sleight to convert an Empire communication profile into mod_rewrite rules and not setup your redirector, simply feed it a communication profile and say no to the "proceed with setup" prompt.
 
+#### CLI arguments:
+If you want to use Sleight non interactively, command line arguments can be found in the default output. Any value not defined at launch will be prompted for during execution.
 
-### Example:
+### Examples:
 $ sudo python sleight.py -c profiles/default.txt
+
+$ sudo python sleight.py --modeHTTPS=y --myDomain=3xample.com --ip=My.C2.IP.Address --redirectDomain=example.com -c profiles/default.txt --proceed=n --port=80

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Sleight can be used in 3 ways:
 #### 3) Rules only (no setup):
 If you only want to use Sleight to convert an Empire communication profile into mod_rewrite rules and not setup your redirector, simply feed it a communication profile and say no to the "proceed with setup" prompt.
 
-#### CLI arguments:
+#### 4) CLI arguments:
 If you want to use Sleight non interactively, command line arguments can be found in the default output. Any value not defined at launch will be prompted for during execution.
 
 ### Examples:

--- a/sleight.py
+++ b/sleight.py
@@ -91,6 +91,7 @@ def shutdown():
 
 def convert_profile():
     # Get LHOST, LPORT and redirect site
+    print args.ip
     if args.ip:
 	# Get LHOST, LPORT and redirect site
  		LHOST = args.ip
@@ -338,14 +339,19 @@ if __name__ == "__main__":
 	try:
 		rules = convert_profile()
 		
-		configure = args.proceed
-
-		if configure == 'y':
-			get_apache()
-			mod_rewrite_config(rules)
-			write_rules(rules)			
-		else:
-			sys.exit((R + '[!]' + W + ' Exiting. Redirector' +
+        if args.proceed:
+            configure = args.proceed
+        else:
+            configure = raw_input(
+                (G + '[+]' + W + ' Proceed with redirector setup?' +
+                    ' [y/N] ')
+                )
+        if configure == 'y':
+            get_apache()
+            mod_rewrite_config(rules)
+            write_rules(rules)			
+        else:
+            sys.exit((R + '[!]' + W + ' Exiting. Redirector' +
 				' not configured.'))
 
 		print LG + '[!] Setup complete!' + W

--- a/sleight.py
+++ b/sleight.py
@@ -91,7 +91,6 @@ def shutdown():
 
 def convert_profile():
     # Get LHOST, LPORT and redirect site
-    print args.ip
     if args.ip:
 	# Get LHOST, LPORT and redirect site
  		LHOST = args.ip

--- a/sleight.py
+++ b/sleight.py
@@ -3,7 +3,7 @@
 
 ############################################################################################
 # sleight.py:   Empire HTTP(S) C2 redirector setup script
-# Author:   VIVI | <Blog: thevivi.net> | <Twitter: @_theVIVI> | <Email: gabriel@thevivi.net> 
+# Author:   VIVI | <Blog: thevivi.net> | <Twitter: @_theVIVI> | <Email: gabriel@thevivi.net>
 ############################################################################################
 
 import subprocess
@@ -35,48 +35,48 @@ def parse_args():
 
     parser.add_argument(
         '-c',
-        '--commProfile',    
+        '--commProfile',
         help='Path to Empire Communication Profile',
         required=True
     )
 
     parser.add_argument(
         '-r',
-        '--redirectDomain',    
+        '--redirectDomain',
         help='Domain bad traffic will be redirected to.',
         required=True
     )
 
     parser.add_argument(
         '-p',
-        '--port',    
+        '--port',
         help='Port that the remote C2 is listening on',
         required=False
     )
 
     parser.add_argument(
         '-i',
-        '--ip',    
+        '--ip',
         help='IP Address of the remote C2 listener',
         required=False
     )
 
     parser.add_argument(
         '-m',
-        '--modeHTTPS',    
+        '--modeHTTPS',
         help='HTTPS Listener for redirector? [y/N]',
         required=False
     )
 
     parser.add_argument(
         '-t',
-        '--myDomain',    
+        '--myDomain',
         help='Domain name for redirector',
         required=False
     )
     parser.add_argument(
         '-q',
-        '--proceed',    
+        '--proceed',
         help='Proceed with configuration of HTTPS Redirector and Cert Deployment [y/N]',
         required=False
     )
@@ -100,7 +100,7 @@ def convert_profile():
         '\n' + G + '[+]' + W + ' Empire C2 LHOST: ')
         while LHOST == '':
             LHOST = raw_input("[-] Empire C2 LHOST: ")
- 
+
     if args.port:
 		LPORT = args.port
     else:
@@ -129,7 +129,7 @@ def convert_profile():
     cp_file = commProfile.read()
     commProfile.close()
     profile = re.sub(r'(?m)^\#.*\n?', '', cp_file).strip('\n')
-    
+
     # GET request URI(s)
     uri_string = profile.split('|')[0]
     uri = uri_string.replace('\"','').replace(',','|').replace(',','|').strip('/')
@@ -146,7 +146,7 @@ def convert_profile():
     	rules = (htaccess_template_https.format(uri,user_agent,LHOST,LPORT,redirect))
     else:
     	rules = (htaccess_template.format(uri,user_agent,LHOST,LPORT,redirect))
-    
+
     print LG + '\n[!]' + W + ' mod_rewrite rules generated.'
     print rules
     return rules
@@ -172,7 +172,7 @@ def get_https_cert():
 
     # Generate HTTPS certificate
     print '\n' + T + '[*]' + W + ' Generating Let\'s Encrypt HTTPS certificate...'
-    
+
     if not args.myDomain:
         domain = raw_input(
             '\n' + G + '[+]' + W + ' Redirector domain (e.g. example.com): ')
@@ -189,21 +189,21 @@ def get_https_cert():
     if args.proceed:
         subprocess.call(['./certbot-auto', 'certonly', '--standalone', '-d', \
     	str(domain), '-d', 'www.'+str(domain), '--register-unsafely-without-email', '--agree-tos', '--non-interactive'])
-    
+
     else:
         subprocess.call(['./certbot-auto', 'certonly', '--standalone', '-d', \
     	str(domain), '-d', 'www.'+str(domain)])
-    
+
     cert_dir = '/etc/letsencrypt/live/'+str(domain)
     if not os.path.isdir(str(cert_dir)):
     	print '\n' + R + '[!]' + W + ' HTTPS certificate for ' \
-    	+ T + str(domain) + W + ' not generated.' 
+    	+ T + str(domain) + W + ' not generated.'
     	sys.exit((R + '[!]' + W + ' Exiting. HTTPS certificate' +
     		' generation failed.'))
     else:
 		print LG + '\n[!]' + W + ' HTTPS certificate for ' \
     	+ T + str(domain) + W + ' successfully generated.'
-    
+
     return domain
 
 def mod_rewrite_config(rules):
@@ -226,7 +226,7 @@ def mod_rewrite_config(rules):
 
 	# Enable mod_rewrite modules
 	subprocess.call(['a2enmod', 'rewrite', 'proxy', 'proxy_http'])
-	
+
 	# HTTPS configuration
 	f = re.split("\n", rules)
 	if 'https' in f[4]:
@@ -246,7 +246,7 @@ def mod_rewrite_config(rules):
 		ssl1 = open('/etc/apache2/sites-enabled/default-ssl.conf', 'r')
 		old_config = ssl1.read()
 		ssl1.close()
-		
+
 		ssl_settings = '''
 		SSLEngine On
 		# Enable Proxy
@@ -259,9 +259,9 @@ def mod_rewrite_config(rules):
 		ssl_on_tag = re.compile(r"SSL Engine Switch:.*?A self-signed", flags=re.DOTALL)
 		new_config = ssl_on_tag.sub(lambda match: \
 			match.group(0).replace('SSLEngine on',str(ssl_settings)) ,old_config)
-		
+
 		cert_settings = '''#   SSLCertificateFile directive is needed.
-		
+
 		# Certificate files for {}
 		#SSLCertificateFile      /etc/letsencrypt/live/{}/cert.pem
 		SSLCertificateFile      /etc/letsencrypt/live/{}/fullchain.pem
@@ -291,7 +291,7 @@ def mod_rewrite_config(rules):
 		print LG + '\n[!]' + W + ' mod_rewrite enabled.\n'
 
 def write_rules(rules):
-	
+
 	# Write rules to .htaccess
 	ruleset = str(rules).strip('\n')
 	htaccess = open('/var/www/html/.htaccess', 'w')
@@ -309,7 +309,7 @@ def write_rules(rules):
 # Main section
 if __name__ == "__main__":
 
-	print """                         
+	print """
 	                       .------.
 	    .------.           |A .   |
 	    |A_  _ |    .------; / \  |
@@ -319,13 +319,13 @@ if __name__ == "__main__":
 	    `-----+'\  / | Y  A|
 	          |  \/ A|-----'
 	          `------'
-	     ▄▄ ▝▜       ▝      ▐    ▗  
-	    ▐▘ ▘ ▐   ▄▖ ▗▄   ▄▄ ▐▗▖ ▗▟▄ 
-	    ▝▙▄  ▐  ▐▘▐  ▐  ▐▘▜ ▐▘▐  ▐  
-	      ▝▌ ▐  ▐▀▀  ▐  ▐ ▐ ▐ ▐  ▐  
-	    ▝▄▟▘ ▝▄ ▝▙▞ ▗▟▄ ▝▙▜ ▐ ▐  ▝▄ 
-	                     ▖▐         
-	                     ▝▘         
+	     ▄▄ ▝▜       ▝      ▐    ▗
+	    ▐▘ ▘ ▐   ▄▖ ▗▄   ▄▄ ▐▗▖ ▗▟▄
+	    ▝▙▄  ▐  ▐▘▐  ▐  ▐▘▜ ▐▘▐  ▐
+	      ▝▌ ▐  ▐▀▀  ▐  ▐ ▐ ▐ ▐  ▐
+	    ▝▄▟▘ ▝▄ ▝▙▞ ▗▟▄ ▝▙▜ ▐ ▐  ▝▄
+	                     ▖▐
+	                     ▝▘
 	"""
 
 	# Parse args
@@ -338,20 +338,19 @@ if __name__ == "__main__":
 
 	try:
 		rules = convert_profile()
-		
-        if args.proceed:
-            configure = args.proceed
-        else:
-            configure = raw_input(
-                (G + '[+]' + W + ' Proceed with redirector setup?' +
+		if args.proceed:
+			configure = args.proceed
+		else:
+			configure = raw_input(
+                G + '[+]' + W + ' Proceed with redirector setup?' +
                     ' [y/N] ')
-                )
-        if configure == 'y':
-            get_apache()
-            mod_rewrite_config(rules)
-            write_rules(rules)			
-        else:
-            sys.exit((R + '[!]' + W + ' Exiting. Redirector' +
+
+		if configure == 'y':
+			get_apache()
+			mod_rewrite_config(rules)
+			write_rules(rules)
+		else:
+			sys.exit((R + '[!]' + W + ' Exiting. Redirector' +
 				' not configured.'))
 
 		print LG + '[!] Setup complete!' + W

--- a/sleight.py
+++ b/sleight.py
@@ -40,6 +40,47 @@ def parse_args():
         required=True
     )
 
+    parser.add_argument(
+        '-r',
+        '--redirectDomain',    
+        help='Domain bad traffic will be redirected to.',
+        required=True
+    )
+
+    parser.add_argument(
+        '-p',
+        '--port',    
+        help='Port that the remote C2 is listening on',
+        required=False
+    )
+
+    parser.add_argument(
+        '-i',
+        '--ip',    
+        help='IP Address of the remote C2 listener',
+        required=False
+    )
+
+    parser.add_argument(
+        '-m',
+        '--modeHTTPS',    
+        help='HTTPS Listener for redirector? [y/N]',
+        required=False
+    )
+
+    parser.add_argument(
+        '-t',
+        '--myDomain',    
+        help='Domain name for redirector',
+        required=False
+    )
+    parser.add_argument(
+        '-q',
+        '--proceed',    
+        help='Proceed with configuration of HTTPS Redirector and Cert Deployment [y/N]',
+        required=False
+    )
+
     return parser.parse_args()
 
 def shutdown():
@@ -49,29 +90,41 @@ def shutdown():
    sys.exit()
 
 def convert_profile():
-
     # Get LHOST, LPORT and redirect site
-    LHOST = raw_input(
+    print args.ip
+    if args.ip:
+	# Get LHOST, LPORT and redirect site
+ 		LHOST = args.ip
+    else:
+        LHOST = raw_input(
         '\n' + G + '[+]' + W + ' Empire C2 LHOST: ')
-    while LHOST == '':
-        LHOST = raw_input("[-] Empire C2 LHOST: ")
-    
-    LPORT = raw_input(
-    	G + '[+]' + W + ' Empire C2 LPORT: ')
-    while LPORT == '':
-        LPORT = raw_input("[-] Empire C2 LPORT: ")
-	
-    HTTPS = raw_input(
-    	G + '[+]' + W + ' HTTPS listener? [y/N]: ')
-    while HTTPS == '':
-        HTTPS = raw_input("[-] HTTPS listener? [y/N]: ")
-   
-    redirect = raw_input(
-        G + '[+]' + W + ' Redirect Site URL: ')
-    while redirect == '':
-        redirect = raw_input("[-] Redirect Site URL: ")
+        while LHOST == '':
+            LHOST = raw_input("[-] Empire C2 LHOST: ")
+ 
+    if args.port:
+		LPORT = args.port
+    else:
+        LPORT = raw_input(
+        G + '[+]' + W + ' Empire C2 LPORT: ')
+        while LPORT == '':
+            LPORT = raw_input("[-] Empire C2 LPORT: ")
 
-    # Read communication profile
+    if args.modeHTTPS:
+		HTTPS = args.modeHTTPS
+    else:
+        HTTPS = raw_input(
+        G + '[+]' + W + ' HTTPS listener? [y/N]: ')
+        while HTTPS == '':
+            HTTPS = raw_input("[-] HTTPS listener? [y/N]: ")
+
+    if args.redirectDomain:
+        redirect = args.redirectDomain
+    else:
+        redirect = raw_input(
+        G + '[+]' + W + ' Redirect Site URL: ')
+        while redirect == '':
+            redirect = raw_input("[-] Redirect Site URL: ")
+
     commProfile = open(args.commProfile, 'r')
     cp_file = commProfile.read()
     commProfile.close()
@@ -108,7 +161,7 @@ def get_apache():
         )
         if install == 'y':
             print '\n' + T + '[*]' + W + ' Installing Apache...\n'
-            subprocess.call(['apt-get', 'update'])
+            subprocess.call(['apt-get', 'update','-y'])
             subprocess.call(['apt-get','install','apache2','-y'])
             print LG + '\n[!]' + W + ' Apache installed.'
         else:
@@ -120,17 +173,25 @@ def get_https_cert():
     # Generate HTTPS certificate
     print '\n' + T + '[*]' + W + ' Generating Let\'s Encrypt HTTPS certificate...'
     
-    domain = raw_input(
-        '\n' + G + '[+]' + W + ' Redirector domain (e.g. example.com): ')
-    while domain == '':
-        domain = raw_input("[-] Redirector domain (e.g. example.com): ")
-
+    if not args.myDomain:
+        domain = raw_input(
+            '\n' + G + '[+]' + W + ' Redirector domain (e.g. example.com): ')
+        while domain == '':
+            domain = raw_input("[-] Redirector domain (e.g. example.com): ")
+    else:
+		domain = args.myDomain
     print '\n' + T + '[*]' + W + ' Runnning certbot. This might take some time...\n'
     if not os.path.isfile("./certbot-auto"):
     	subprocess.call(['wget', 'https://dl.eff.org/certbot-auto'])
     subprocess.call(['chmod', 'a+x', './certbot-auto'])
     subprocess.call(['service', 'apache2', 'stop'])
-    subprocess.call(['./certbot-auto', 'certonly', '--standalone', '-d', \
+# TODO: add sub domain enumeration here, so news,images,www,static can be fed as a CLI arg and the array is parsed as multiple -d options.
+    if args.proceed:
+        subprocess.call(['./certbot-auto', 'certonly', '--standalone', '-d', \
+    	str(domain), '-d', 'www.'+str(domain), '--register-unsafely-without-email', '--agree-tos', '--non-interactive'])
+    
+    else:
+        subprocess.call(['./certbot-auto', 'certonly', '--standalone', '-d', \
     	str(domain), '-d', 'www.'+str(domain)])
     
     cert_dir = '/etc/letsencrypt/live/'+str(domain)
@@ -202,10 +263,11 @@ def mod_rewrite_config(rules):
 		cert_settings = '''#   SSLCertificateFile directive is needed.
 		
 		# Certificate files for {}
-		SSLCertificateFile      /etc/letsencrypt/live/{}/cert.pem
+		#SSLCertificateFile      /etc/letsencrypt/live/{}/cert.pem
+		SSLCertificateFile      /etc/letsencrypt/live/{}/fullchain.pem
 		SSLCertificateKeyFile      /etc/letsencrypt/live/{}/privkey.pem
 
-		#   Server Certificate Chain:'''.format(domain, domain, domain)
+		#   Server Certificate Chain:'''.format(domain, domain, domain, domain)
 
 		certs_tag = re.compile(r"#   SSLCertificateFile directive is needed..*?#   Server Certificate Chain:", \
 			flags=re.DOTALL)
@@ -277,10 +339,7 @@ if __name__ == "__main__":
 	try:
 		rules = convert_profile()
 		
-		configure = raw_input(
-			(G + '[+]' + W + ' Proceed with redirector setup?' +
-				' [y/N] ')
-			)
+		configure = args.proceed
 
 		if configure == 'y':
 			get_apache()


### PR DESCRIPTION
Hello,
I was pushing this script as part of a deployment process and found the need to have the values passed from bash. I figured instead of echo'ing my answers or using expect, I would just add parameters to the CLI of sleight.py.

Originally when testing Sleight, I was having inconsistent results with the Let's Encrypt cert. Even though the cert was successfully deployed, multiple browsers wouldn't accept the cert as valid/secure while others would have no issues. My research suggested using fullchain.pem instead of cert.pem, which did in fact fix the issue for me.

Added -y to an apt-get update, --agree-tos and a few other commands to the certbot-auto execution, just small things that seemed to polish up the autonomous execution.